### PR TITLE
jenkins x master

### DIFF
--- a/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/.lighthouse/jenkins-x/pullrequest.yaml
@@ -11,7 +11,7 @@ spec:
       taskSpec:
         metadata: {}
         stepTemplate:
-          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/go/release.yaml@b52a202405538287e2058b754aa761cd17baf2d7
+          image: uses:jenkins-x/jx3-pipeline-catalog/tasks/go/release.yaml@a5ab19ebc5a074e0402c5016b11bc11b32cc5c83
           name: ""
           resources:
             requests:
@@ -32,7 +32,7 @@ spec:
               secretKeyRef:
                 key: password
                 name: bdd-git
-          image: ghcr.io/jenkins-x/jx-go-maven:latest
+          image: ghcr.io/jenkins-x/jx-go-maven:3.2.197
           name: runci
           resources: {}
           script: |

--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,8 @@
+approvers:
+- rawlingsj
+- jstrachan
+- rajdavies
+reviewers:
+- rawlingsj
+- jstrachan
+- rajdavies

--- a/packs/git/.lighthouse/jenkins-x/release.yaml
+++ b/packs/git/.lighthouse/jenkins-x/release.yaml
@@ -19,7 +19,7 @@ spec:
               memory: 600Mi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+        - image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
@@ -36,7 +36,11 @@ spec:
               secretKeyRef:
                 name: tekton-git
                 key: username
+<<<<<<< HEAD
         - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+=======
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
+>>>>>>> e74c795989c16092d4cc5cf31a2f09db4b042251
           name: jx-variables
           resources: {}
           script: |

--- a/tasks/C++/pullrequest.yaml
+++ b/tasks/C++/pullrequest.yaml
@@ -22,7 +22,7 @@ spec:
           resources: {}
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -44,7 +44,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/C++/release.yaml
+++ b/tasks/C++/release.yaml
@@ -33,13 +33,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -60,7 +60,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |
@@ -88,14 +88,14 @@ spec:
             git push --force origin v$VERSION
 
             jx changelog create --version v${VERSION}
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-helm-release
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.278
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.1.0
           name: promote-jx-promote
           resources: {}
           script: |

--- a/tasks/D/pullrequest.yaml
+++ b/tasks/D/pullrequest.yaml
@@ -25,7 +25,7 @@ spec:
               memory: 1Gi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -41,7 +41,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/D/release.yaml
+++ b/tasks/D/release.yaml
@@ -36,13 +36,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -57,7 +57,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |
@@ -85,14 +85,14 @@ spec:
             git push --force origin v$VERSION
 
             jx changelog create --version v${VERSION}
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-helm-release
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.278
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.1.0
           name: promote-jx-promote
           resources: {}
           script: |

--- a/tasks/apps/pullrequest.yaml
+++ b/tasks/apps/pullrequest.yaml
@@ -25,7 +25,7 @@ spec:
               memory: 600Mi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |

--- a/tasks/apps/release.yaml
+++ b/tasks/apps/release.yaml
@@ -36,13 +36,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -54,7 +54,7 @@ spec:
           script: |
             #!/bin/sh
             make build
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: release-chart
           resources: {}
           script: |
@@ -68,14 +68,14 @@ spec:
           script: |
             #!/bin/sh
             make release
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-helm-release
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.278
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.1.0
           name: promote-jx-promote
           resources: {}
           script: |

--- a/tasks/appserver/pullrequest.yaml
+++ b/tasks/appserver/pullrequest.yaml
@@ -33,7 +33,7 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -56,7 +56,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/appserver/release.yaml
+++ b/tasks/appserver/release.yaml
@@ -44,13 +44,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -65,7 +65,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |
@@ -93,14 +93,14 @@ spec:
             git push --force origin v$VERSION
 
             jx changelog create --version v${VERSION}
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-helm-release
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.278
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.1.0
           name: promote-jx-promote
           resources: {}
           script: |

--- a/tasks/charts/pullrequest.yaml
+++ b/tasks/charts/pullrequest.yaml
@@ -22,7 +22,7 @@ spec:
           resources: {}
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |

--- a/tasks/charts/release.yaml
+++ b/tasks/charts/release.yaml
@@ -33,13 +33,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |

--- a/tasks/csharp/pullrequest.yaml
+++ b/tasks/csharp/pullrequest.yaml
@@ -25,7 +25,7 @@ spec:
               memory: 256Mi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -35,7 +35,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/csharp/release.yaml
+++ b/tasks/csharp/release.yaml
@@ -36,13 +36,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -51,7 +51,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |
@@ -79,14 +79,14 @@ spec:
             git push --force origin v$VERSION
 
             jx changelog create --version v${VERSION}
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-helm-release
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.278
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.1.0
           name: promote-jx-promote
           resources: {}
           script: |

--- a/tasks/custom-jenkins/pullrequest.yaml
+++ b/tasks/custom-jenkins/pullrequest.yaml
@@ -25,7 +25,7 @@ spec:
               memory: 600Mi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |

--- a/tasks/custom-jenkins/release.yaml
+++ b/tasks/custom-jenkins/release.yaml
@@ -36,13 +36,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |

--- a/tasks/cwp/pullrequest.yaml
+++ b/tasks/cwp/pullrequest.yaml
@@ -33,7 +33,7 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -56,7 +56,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/cwp/release.yaml
+++ b/tasks/cwp/release.yaml
@@ -44,13 +44,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -87,7 +87,7 @@ spec:
           - name: MAVEN_OPTS
             value: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
               -Dmaven.wagon.http.retryHandler.count=3
-          image: gcr.io/kaniko-project/executor:debug-v1.3.0
+          image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |
@@ -115,14 +115,14 @@ spec:
             git push --force origin v$VERSION
 
             jx changelog create --version v${VERSION}
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-step6
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-jx
           resources: {}
           script: |

--- a/tasks/docker-helm/pullrequest.yaml
+++ b/tasks/docker-helm/pullrequest.yaml
@@ -25,7 +25,7 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -35,7 +35,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/docker-helm/release.yaml
+++ b/tasks/docker-helm/release.yaml
@@ -36,13 +36,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -51,7 +51,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |
@@ -79,14 +79,14 @@ spec:
             git push --force origin v$VERSION
 
             jx changelog create --version v${VERSION}
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-helm-release
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.278
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.1.0
           name: promote-jx-promote
           resources: {}
           script: |

--- a/tasks/docker/pullrequest.yaml
+++ b/tasks/docker/pullrequest.yaml
@@ -25,7 +25,7 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -35,7 +35,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/docker/release.yaml
+++ b/tasks/docker/release.yaml
@@ -36,13 +36,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -51,7 +51,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/environment/pullrequest.yaml
+++ b/tasks/environment/pullrequest.yaml
@@ -33,7 +33,7 @@ spec:
           - secretRef:
               name: jx-boot-job-env-vars
               optional: true
-          image: ghcr.io/jenkins-x/jx-boot:3.2.196
+          image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: make-pr
           resources: {}
         - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/kubetest/environment.yaml@versionStream

--- a/tasks/flutter/pullrequest.yaml
+++ b/tasks/flutter/pullrequest.yaml
@@ -25,7 +25,7 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |

--- a/tasks/flutter/release.yaml
+++ b/tasks/flutter/release.yaml
@@ -41,13 +41,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |

--- a/tasks/git-clone/git-clone-env-pr.yaml
+++ b/tasks/git-clone/git-clone-env-pr.yaml
@@ -40,7 +40,7 @@ spec:
     - secretRef:
         name: jx-boot-job-env-vars
         optional: true
-    image: ghcr.io/jenkins-x/jx-boot:3.2.196
+    image: ghcr.io/jenkins-x/jx-boot:3.2.202
     name: git-merge
     resources: {}
     script: |

--- a/tasks/git-clone/git-clone-pr.yaml
+++ b/tasks/git-clone/git-clone-pr.yaml
@@ -40,7 +40,7 @@ spec:
     - secretRef:
         name: jx-boot-job-env-vars
         optional: true
-    image: ghcr.io/jenkins-x/jx-boot:3.2.196
+    image: ghcr.io/jenkins-x/jx-boot:3.2.202
     name: git-merge
     resources: {}
     script: |

--- a/tasks/go-cli/pullrequest.yaml
+++ b/tasks/go-cli/pullrequest.yaml
@@ -25,7 +25,7 @@ spec:
               memory: 600Mi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -47,7 +47,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/go-cli/release.yaml
+++ b/tasks/go-cli/release.yaml
@@ -36,13 +36,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -76,7 +76,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/go-mongodb/pullrequest.yaml
+++ b/tasks/go-mongodb/pullrequest.yaml
@@ -25,7 +25,7 @@ spec:
               memory: 600Mi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -41,7 +41,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/go-mongodb/release.yaml
+++ b/tasks/go-mongodb/release.yaml
@@ -36,13 +36,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -57,7 +57,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |
@@ -85,14 +85,14 @@ spec:
             git push --force origin v$VERSION
 
             jx changelog create --version v${VERSION}
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-step6
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-step7
           resources: {}
           script: |

--- a/tasks/go-plugin-multiarch/pullrequest.yaml
+++ b/tasks/go-plugin-multiarch/pullrequest.yaml
@@ -25,7 +25,7 @@ spec:
               memory: 600Mi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -47,7 +47,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/go-plugin-multiarch/release.yaml
+++ b/tasks/go-plugin-multiarch/release.yaml
@@ -33,13 +33,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -52,7 +52,7 @@ spec:
             #!/usr/bin/env bash
             source .jx/variables.sh
             make release
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-and-push-image
           resources: {}
           script: |
@@ -82,7 +82,7 @@ spec:
             else echo no charts; fi
 
             jx changelog create --verbose --header-file=hack/changelog-header.md --version=$VERSION --rev=$PULL_BASE_SHA --output-markdown=changelog.md --update-release=true
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: release-chart
           resources: {}
           script: |

--- a/tasks/go-plugin/pullrequest.yaml
+++ b/tasks/go-plugin/pullrequest.yaml
@@ -25,7 +25,7 @@ spec:
               memory: 600Mi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -38,6 +38,12 @@ spec:
           script: |
             #!/bin/sh
             make linux
+        - image: golangci/golangci-lint:v1.42.1-alpine
+          name: make-lint
+          resources: {}
+          script: |
+            #!/bin/sh
+            golangci-lint run --verbose --deadline 15m0s
         - image: golang:1.15
           name: build-make-test
           resources: {}
@@ -47,7 +53,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/go-plugin/release.yaml
+++ b/tasks/go-plugin/release.yaml
@@ -33,13 +33,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -52,7 +52,7 @@ spec:
             #!/usr/bin/env bash
             source .jx/variables.sh
             make release
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-and-push-image
           resources: {}
           script: |
@@ -82,7 +82,7 @@ spec:
             else echo no charts; fi
 
             jx changelog create --verbose --header-file=hack/changelog-header.md --version=$VERSION --rev=$PULL_BASE_SHA --output-markdown=changelog.md --update-release=true
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: release-chart
           resources: {}
           script: |

--- a/tasks/go/pullrequest.yaml
+++ b/tasks/go/pullrequest.yaml
@@ -25,7 +25,7 @@ spec:
               memory: 600Mi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -38,10 +38,16 @@ spec:
           script: |
             #!/bin/sh
             make linux
+        - image: golangci/golangci-lint:v1.42.1-alpine
+          name: make-lint
+          resources: {}
+          script: |
+            #!/bin/sh
+            golangci-lint run --verbose --deadline 15m0s
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/go/release.yaml
+++ b/tasks/go/release.yaml
@@ -36,13 +36,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -57,7 +57,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |
@@ -85,14 +85,14 @@ spec:
             git push --force origin v$VERSION
 
             jx changelog create --version v${VERSION}
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-helm-release
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.278
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.1.0
           name: promote-jx-promote
           resources: {}
           script: |

--- a/tasks/gradle/pullrequest.yaml
+++ b/tasks/gradle/pullrequest.yaml
@@ -25,7 +25,7 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -41,7 +41,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/gradle/release.yaml
+++ b/tasks/gradle/release.yaml
@@ -36,13 +36,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -57,7 +57,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |
@@ -85,14 +85,14 @@ spec:
             git push --force origin v$VERSION
 
             jx changelog create --version v${VERSION}
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-helm-release
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.278
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.1.0
           name: promote-jx-promote
           resources: {}
           script: |

--- a/tasks/helm/pullrequest.yaml
+++ b/tasks/helm/pullrequest.yaml
@@ -25,14 +25,14 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx gitops variables
             jx gitops pr variables
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: build-helm-build
           resources: {}
           script: |

--- a/tasks/helm/release.yaml
+++ b/tasks/helm/release.yaml
@@ -36,13 +36,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -68,14 +68,14 @@ spec:
             git push --force origin v$VERSION
 
             jx changelog create --version v${VERSION}
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-helm-release
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.278
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.1.0
           name: promote-jx-promote
           resources: {}
           script: |

--- a/tasks/javascript-ui-nginx/pullrequest.yaml
+++ b/tasks/javascript-ui-nginx/pullrequest.yaml
@@ -25,7 +25,7 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -53,7 +53,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/javascript-ui-nginx/release.yaml
+++ b/tasks/javascript-ui-nginx/release.yaml
@@ -41,13 +41,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -74,7 +74,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |
@@ -102,14 +102,14 @@ spec:
             git push --force origin v$VERSION
 
             jx changelog create --version v${VERSION}
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-helm-release
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.278
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.1.0
           name: promote-jx-promote
           resources: {}
           script: |

--- a/tasks/javascript/pullrequest.yaml
+++ b/tasks/javascript/pullrequest.yaml
@@ -30,7 +30,7 @@ spec:
             name: npmrc
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -52,7 +52,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/javascript/release.yaml
+++ b/tasks/javascript/release.yaml
@@ -41,13 +41,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -68,7 +68,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |
@@ -96,14 +96,14 @@ spec:
             git push --force origin v$VERSION
 
             jx changelog create --version v${VERSION}
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-helm-release
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.278
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.1.0
           name: promote-jx-promote
           resources: {}
           script: |

--- a/tasks/jenkins/pullrequest.yaml
+++ b/tasks/jenkins/pullrequest.yaml
@@ -33,7 +33,7 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -43,7 +43,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/jenkins/release.yaml
+++ b/tasks/jenkins/release.yaml
@@ -44,13 +44,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -59,7 +59,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/jenkinsfilerunner/pullrequest.yaml
+++ b/tasks/jenkinsfilerunner/pullrequest.yaml
@@ -22,7 +22,7 @@ spec:
           resources: {}
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |

--- a/tasks/jenkinsfilerunner/release.yaml
+++ b/tasks/jenkinsfilerunner/release.yaml
@@ -33,13 +33,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |

--- a/tasks/lookml/lint.yaml
+++ b/tasks/lookml/lint.yaml
@@ -34,7 +34,7 @@ spec:
               memory: 512Mi
           workingDir: $(workspaces.output.path)/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |

--- a/tasks/lookml/pullrequest.yaml
+++ b/tasks/lookml/pullrequest.yaml
@@ -25,7 +25,7 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |

--- a/tasks/lookml/release.yaml
+++ b/tasks/lookml/release.yaml
@@ -36,13 +36,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -65,14 +65,14 @@ spec:
             git push --force origin v$VERSION
 
             jx changelog create --version v${VERSION}
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-helm-release
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.278
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.1.0
           name: promote-jx-promote
           resources: {}
           script: |

--- a/tasks/maven-java11/pullrequest.yaml
+++ b/tasks/maven-java11/pullrequest.yaml
@@ -35,7 +35,7 @@ spec:
             name: maven-settings
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -58,7 +58,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/maven-java11/release.yaml
+++ b/tasks/maven-java11/release.yaml
@@ -48,13 +48,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -75,7 +75,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |
@@ -103,14 +103,14 @@ spec:
             git commit -a -m "chore: release $VERSION" --allow-empty
             git tag -fa v$VERSION -m "Release version $VERSION"
             git push --force origin v$VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-helm-release
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.278
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.1.0
           name: promote-jx-promote
           resources: {}
           script: |

--- a/tasks/maven-java14/pullrequest.yaml
+++ b/tasks/maven-java14/pullrequest.yaml
@@ -14,7 +14,7 @@ spec:
           env:
           - name: MAVEN_OPTS
             value: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
-              -Dmaven.wagon.http.retryHandler.count=3 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+              -Dmaven.wagon.http.retryHandler.count=3
           - name: HOME
             value: /tekton/home
           envFrom:
@@ -31,7 +31,7 @@ spec:
             name: maven-settings
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -50,11 +50,11 @@ spec:
           script: |
             #!/usr/bin/env bash
             source .jx/variables.sh
-            mvn -B --no-transfer-progress install
+            mvn --no-transfer-progress install
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/maven-java14/release.yaml
+++ b/tasks/maven-java14/release.yaml
@@ -14,7 +14,7 @@ spec:
           env:
           - name: MAVEN_OPTS
             value: -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
-              -Dmaven.wagon.http.retryHandler.count=3 -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
+              -Dmaven.wagon.http.retryHandler.count=3
           - name: HOME
             value: /tekton/home
           envFrom:
@@ -44,13 +44,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -67,11 +67,11 @@ spec:
             echo "upgrading the pom to version $VERSION"
             mvn versions:set -DnewVersion=$VERSION
 
-            mvn -B --no-transfer-progress clean deploy
+            mvn --no-transfer-progress clean deploy
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |
@@ -99,14 +99,14 @@ spec:
             git commit -a -m "chore: release $VERSION" --allow-empty
             git tag -fa v$VERSION -m "Release version $VERSION"
             git push --force origin v$VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-helm-release
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.278
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.1.0
           name: promote-jx-promote
           resources: {}
           script: |

--- a/tasks/maven-java16/pullrequest.yaml
+++ b/tasks/maven-java16/pullrequest.yaml
@@ -31,7 +31,7 @@ spec:
             name: maven-settings
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -54,7 +54,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/maven-java16/release.yaml
+++ b/tasks/maven-java16/release.yaml
@@ -44,13 +44,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -68,22 +68,10 @@ spec:
             mvn versions:set -DnewVersion=$VERSION
 
             mvn --no-transfer-progress clean deploy
-        - image: maven:3.8-openjdk-16
-          name: build-mvn-install
-          resources: {}
-          script: |
-            #!/usr/bin/env bash
-            source .jx/variables.sh
-
-            # modify the pom.xml
-            echo "upgrading the pom to version $VERSION"
-            mvn versions:set -DnewVersion=$VERSION
-
-            mvn --no-transfer-progress install
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |
@@ -111,14 +99,14 @@ spec:
             git commit -a -m "chore: release $VERSION" --allow-empty
             git tag -fa v$VERSION -m "Release version $VERSION"
             git push --force origin v$VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-helm-release
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.278
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.1.0
           name: promote-jx-promote
           resources: {}
           script: |

--- a/tasks/maven-node-ruby/pullrequest.yaml
+++ b/tasks/maven-node-ruby/pullrequest.yaml
@@ -36,7 +36,7 @@ spec:
             name: maven-settings
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -60,7 +60,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/maven-node-ruby/release.yaml
+++ b/tasks/maven-node-ruby/release.yaml
@@ -49,13 +49,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -76,7 +76,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |
@@ -104,14 +104,14 @@ spec:
             git commit -a -m "chore: release $VERSION" --allow-empty
             git tag -fa v$VERSION -m "Release version $VERSION"
             git push --force origin v$VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-helm-release
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.278
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.1.0
           name: promote-jx-promote
           resources: {}
           script: |

--- a/tasks/maven-quarkus-native/pullrequest.yaml
+++ b/tasks/maven-quarkus-native/pullrequest.yaml
@@ -35,7 +35,7 @@ spec:
             name: maven-settings
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -58,7 +58,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/maven-quarkus-native/release.yaml
+++ b/tasks/maven-quarkus-native/release.yaml
@@ -48,13 +48,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -81,7 +81,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |
@@ -109,14 +109,14 @@ spec:
             git commit -a -m "chore: release $VERSION" --allow-empty
             git tag -fa v$VERSION -m "Release version $VERSION"
             git push --force origin v$VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-helm-release
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.278
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.1.0
           name: promote-jx-promote
           resources: {}
           script: |

--- a/tasks/maven-quarkus/pullrequest.yaml
+++ b/tasks/maven-quarkus/pullrequest.yaml
@@ -35,7 +35,7 @@ spec:
             name: maven-settings
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -58,7 +58,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/maven-quarkus/release.yaml
+++ b/tasks/maven-quarkus/release.yaml
@@ -48,13 +48,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -75,7 +75,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |
@@ -103,14 +103,14 @@ spec:
             git commit -a -m "chore: release $VERSION" --allow-empty
             git tag -fa v$VERSION -m "Release version $VERSION"
             git push --force origin v$VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-helm-release
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.278
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.1.0
           name: promote-jx-promote
           resources: {}
           script: |

--- a/tasks/maven/pullrequest.yaml
+++ b/tasks/maven/pullrequest.yaml
@@ -36,7 +36,7 @@ spec:
             name: maven-settings
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -59,7 +59,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/maven/release.yaml
+++ b/tasks/maven/release.yaml
@@ -49,13 +49,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -76,7 +76,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |
@@ -104,14 +104,14 @@ spec:
             git commit -a -m "chore: release $VERSION" --allow-empty
             git tag -fa v$VERSION -m "Release version $VERSION"
             git push --force origin v$VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-helm-release
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.278
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.1.0
           name: promote-jx-promote
           resources: {}
           script: |

--- a/tasks/ml-python-gpu-service/pullrequest.yaml
+++ b/tasks/ml-python-gpu-service/pullrequest.yaml
@@ -25,7 +25,7 @@ spec:
               memory: 1Gi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -57,7 +57,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/ml-python-gpu-service/release.yaml
+++ b/tasks/ml-python-gpu-service/release.yaml
@@ -36,13 +36,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -72,7 +72,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |
@@ -100,14 +100,14 @@ spec:
             git push --force origin v$VERSION
 
             jx changelog create --version v${VERSION}
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-helm-release
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.278
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.1.0
           name: promote-jx-promote
           resources: {}
           script: |

--- a/tasks/ml-python-gpu-training/pullrequest.yaml
+++ b/tasks/ml-python-gpu-training/pullrequest.yaml
@@ -25,7 +25,7 @@ spec:
               memory: 4Gi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |

--- a/tasks/ml-python-gpu-training/release.yaml
+++ b/tasks/ml-python-gpu-training/release.yaml
@@ -41,13 +41,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -87,7 +87,7 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-boot:3.2.196
+          image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: build-export-model
           resources: {}
           script: |+

--- a/tasks/ml-python-service/pullrequest.yaml
+++ b/tasks/ml-python-service/pullrequest.yaml
@@ -25,7 +25,7 @@ spec:
               memory: 4Gi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -57,7 +57,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/ml-python-service/release.yaml
+++ b/tasks/ml-python-service/release.yaml
@@ -36,13 +36,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -72,7 +72,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |
@@ -100,14 +100,14 @@ spec:
             git push --force origin v$VERSION
 
             jx changelog create --version v${VERSION}
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-step8
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.278
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.1.0
           name: promote-jx-promote
           resources: {}
           script: |

--- a/tasks/ml-python-training/pullrequest.yaml
+++ b/tasks/ml-python-training/pullrequest.yaml
@@ -25,7 +25,7 @@ spec:
               memory: 4Gi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |

--- a/tasks/ml-python-training/release.yaml
+++ b/tasks/ml-python-training/release.yaml
@@ -36,13 +36,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -74,7 +74,7 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-boot:3.2.196
+          image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: build-export-model
           resources: {}
           script: |+

--- a/tasks/nop/pullrequest.yaml
+++ b/tasks/nop/pullrequest.yaml
@@ -22,14 +22,14 @@ spec:
           resources: {}
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx gitops variables
             jx gitops pr variables
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: build-dummy-build
           resources: {}
           script: |

--- a/tasks/nop/release.yaml
+++ b/tasks/nop/release.yaml
@@ -33,19 +33,19 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx gitops variables
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: build-dummy-release
           resources: {}
           script: |

--- a/tasks/php/pullrequest.yaml
+++ b/tasks/php/pullrequest.yaml
@@ -25,7 +25,7 @@ spec:
               memory: 256Mi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -35,7 +35,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/php/release.yaml
+++ b/tasks/php/release.yaml
@@ -36,13 +36,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -51,7 +51,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |
@@ -79,14 +79,14 @@ spec:
             git push --force origin v$VERSION
 
             jx changelog create --version v${VERSION}
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-helm-release
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.278
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.1.0
           name: promote-jx-promote
           resources: {}
           script: |

--- a/tasks/python/pullrequest.yaml
+++ b/tasks/python/pullrequest.yaml
@@ -25,7 +25,7 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -41,7 +41,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/python/release.yaml
+++ b/tasks/python/release.yaml
@@ -36,13 +36,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -57,7 +57,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |
@@ -85,14 +85,14 @@ spec:
             git push --force origin v$VERSION
 
             jx changelog create --version v${VERSION}
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-helm-release
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.278
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.1.0
           name: promote-jx-promote
           resources: {}
           script: |

--- a/tasks/ruby/pullrequest.yaml
+++ b/tasks/ruby/pullrequest.yaml
@@ -25,7 +25,7 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -35,7 +35,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/ruby/release.yaml
+++ b/tasks/ruby/release.yaml
@@ -36,13 +36,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -51,7 +51,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |
@@ -79,14 +79,14 @@ spec:
             git push --force origin v$VERSION
 
             jx changelog create --version v${VERSION}
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-helm-release
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.278
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.1.0
           name: promote-jx-promote
           resources: {}
           script: |

--- a/tasks/rust/pullrequest.yaml
+++ b/tasks/rust/pullrequest.yaml
@@ -25,7 +25,7 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -41,7 +41,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/rust/release.yaml
+++ b/tasks/rust/release.yaml
@@ -36,13 +36,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -57,7 +57,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |
@@ -85,14 +85,14 @@ spec:
             git push --force origin v$VERSION
 
             jx changelog create --version v${VERSION}
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-helm-release
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.278
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.1.0
           name: promote-jx-promote
           resources: {}
           script: |

--- a/tasks/scala/pullrequest.yaml
+++ b/tasks/scala/pullrequest.yaml
@@ -33,7 +33,7 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -49,7 +49,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/scala/release.yaml
+++ b/tasks/scala/release.yaml
@@ -44,13 +44,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -65,7 +65,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |
@@ -93,14 +93,14 @@ spec:
             git push --force origin v$VERSION
 
             jx changelog create --version v${VERSION}
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-helm-release
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.278
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.1.0
           name: promote-jx-promote
           resources: {}
           script: |

--- a/tasks/terraform/pullrequest.yaml
+++ b/tasks/terraform/pullrequest.yaml
@@ -25,7 +25,7 @@ spec:
               memory: 600Mi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |

--- a/tasks/terraform/release.yaml
+++ b/tasks/terraform/release.yaml
@@ -36,13 +36,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |

--- a/tasks/typescript/pullrequest.yaml
+++ b/tasks/typescript/pullrequest.yaml
@@ -27,7 +27,7 @@ spec:
               memory: 512Mi
           workingDir: /workspace/source
         steps:
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -49,7 +49,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |

--- a/tasks/typescript/release.yaml
+++ b/tasks/typescript/release.yaml
@@ -41,13 +41,13 @@ spec:
               secretKeyRef:
                 key: username
                 name: tekton-git
-          image: ghcr.io/jenkins-x/jx-release-version:2.4.13
+          image: ghcr.io/jenkins-x/jx-release-version:2.5.0
           name: next-version
           resources: {}
           script: |
             #!/usr/bin/env sh
             jx-release-version --tag > VERSION
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: jx-variables
           resources: {}
           script: |
@@ -68,7 +68,7 @@ spec:
         - image: ghcr.io/jenkins-x/jx-registry:0.1.1
           name: check-registry
           resources: {}
-        - image: gcr.io/kaniko-project/executor:debug-v1.3.0
+        - image: gcr.io/kaniko-project/executor:v1.6.0-debug
           name: build-container-build
           resources: {}
           script: |
@@ -96,14 +96,14 @@ spec:
             git push --force origin v$VERSION
 
             jx changelog create --version v${VERSION}
-        - image: ghcr.io/jenkins-x/jx-boot:3.2.196
+        - image: ghcr.io/jenkins-x/jx-boot:3.2.202
           name: promote-helm-release
           resources: {}
           script: |
             #!/usr/bin/env sh
             source .jx/variables.sh
             jx gitops helm release
-        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.0.278
+        - image: ghcr.io/jenkins-x-plugins/jx-promote:0.1.0
           name: promote-jx-promote
           resources: {}
           script: |


### PR DESCRIPTION
- chore(deps): upgrade jenkins-x/jx3-pipeline-catalog to version 3.2.196
- chore: upgrade environment pull request to f70a21d7a7061734cf0490e58d9d554b665488d9
- chore(deps): upgrade jenkins-x/jx3-pipeline-catalog to version 3.2.197
- chore: upgrade environment pull request to 7b9efe07b81e3ca01ca4a70a988c5e91bfb2440b
- chore(deps): upgrade jenkins-x/jx3-pipeline-catalog to version 2.5.0
- chore: upgrade environment pull request to a5ab19ebc5a074e0402c5016b11bc11b32cc5c83
- chore: use latest release versions and shas
- refactor: upgrade kaniko docker image to 1.6.0
- chore(deps): upgrade jenkins-x/jx3-pipeline-catalog to version 3.2.198
- chore: upgrade environment pull request to 061dacd5886aed1fec6e62fb2ff9b2596734b63f
- Create OWNERS
- chore: upgrade environment pull request to b764189e42277ad807f94bd75a056cbd0ded25db
- chore: upgrade environment pull request to 7b0af9bca06469dc0118dd4393f576c3a614cab7
- feat: add a lint step for go pr task
- chore(deps): upgrade jenkins-x/jx3-pipeline-catalog to version 3.2.199
- chore: upgrade environment pull request to 9ada158068b622da3a2b9ee7fffb72aa3c475366
- chore: upgrade environment pull request to 22e1566af9b6d56bd0eacd54a1db038a71b77555
- chore(deps): upgrade jenkins-x/jx3-pipeline-catalog to version 0.1.0
- chore: upgrade environment pull request to 8afe9c8085938016a9faf5fbdd488d111eceed2e
- chore(deps): upgrade jenkins-x/jx3-pipeline-catalog to version 3.2.200
- chore: upgrade environment pull request to dab52dc2a15a2672245aa0440379ac15a7edbc1d
- chore(deps): upgrade jenkins-x/jx3-pipeline-catalog to version 3.2.201
- chore: upgrade environment pull request to d34fa009f38338fbee3c58080ab37cc50907899c
- chore(deps): upgrade jenkins-x/jx3-pipeline-catalog to version 3.2.202
- chore: upgrade environment pull request to 160e5e8dbf56cf7b2ff4398beec6f15e9feda384
