### PR TITLE
chore: removed task to wait for sonar quality gate

### DIFF
--- a/tasks/mentor-maven/pullrequest.yaml
+++ b/tasks/mentor-maven/pullrequest.yaml
@@ -24,9 +24,6 @@ spec:
         - name: build-set-version
         - image: uses:Mentor-Medier/jx3-pipeline-catalog/tasks/maven-sonar/pullrequest.yaml@HEAD
           name: sonarscan
-
-        - image: uses:Mentor-Medier/jx3-pipeline-catalog/tasks/maven-sonar/pullrequest.yaml@HEAD
-          name: sonar-quality-gate
         - name: check-registry
         - image: uses:Mentor-Medier/jx3-pipeline-catalog/tasks/build-scan-push/build-scan-push.yaml@HEAD
           name: ""


### PR DESCRIPTION
as it is already waiting for quality gate  in the maven-sonar task